### PR TITLE
Address object-path vulnerability.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://art-bobcat.autodesk.com/artifactory/api/npm/autodesk-npm-virtual/

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://art-bobcat.autodesk.com/artifactory/api/npm/autodesk-npm-virtual/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Live version here: http://dictionary.dynamobim.com
 
 - Node.js version 12 is required. [Download the installer here](https://nodejs.org) (or use [nvm](https://github.com/nvm-sh/nvm).)
 - Run `npm install` from the command line in the project root directory.
+- Note that the `project-lock.json` file has URLs that point to an Autodesk internal NPM mirror.  If you do not have access to that mirror, you will need to delete the `package-lock.json` before `npm install` will succeed.
 
 ## Run the Development Server
 - Run `npm start` from the command line in the project root directory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1957,48 +1957,6 @@
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/address/-/address-1.1.2.tgz",
       "integrity": "sha1-vxEWycdYxRt6kz0pa3LCIe2UKLY="
     },
-    "adjust-sourcemap-loader": {
-      "version": "2.0.0",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/adjust-sourcemap-loader/-/adjust-sourcemap-loader-2.0.0.tgz",
-      "integrity": "sha1-ZHEUOvdewCM0shn1S8eXDFL7KaQ=",
-      "requires": {
-        "assert": "1.4.1",
-        "camelcase": "5.0.0",
-        "loader-utils": "1.2.3",
-        "object-path": "0.11.4",
-        "regex-parser": "2.2.10"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.0.0",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/camelcase/-/camelcase-5.0.0.tgz",
-          "integrity": "sha1-AylVJ9WL081Kp1Nj81sujZe+L0I="
-        },
-        "emojis-list": {
-          "version": "2.1.0",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/emojis-list/-/emojis-list-2.1.0.tgz",
-          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
-        },
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "loader-utils": {
-          "version": "1.2.3",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/loader-utils/-/loader-utils-1.2.3.tgz",
-          "integrity": "sha1-H/XcaRHJ8KBiUxpMBLYJQGEIwsc=",
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^2.0.0",
-            "json5": "^1.0.1"
-          }
-        }
-      }
-    },
     "aggregate-error": {
       "version": "3.0.1",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -9028,11 +8986,6 @@
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
     },
-    "object-path": {
-      "version": "0.11.4",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/object-path/-/object-path-0.11.4.tgz",
-      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
-    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/object-visit/-/object-visit-1.0.1.tgz",
@@ -11140,9 +11093,9 @@
       }
     },
     "react-scripts": {
-      "version": "3.4.3",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/react-scripts/-/react-scripts-3.4.3.tgz",
-      "integrity": "sha1-Id5euT3kHuks0LhbDhKY0LsubFE=",
+      "version": "3.4.4",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/react-scripts/-/react-scripts-3.4.4.tgz",
+      "integrity": "sha1-7vAk7VxWY3QAXj9QmHc1C6mdCKc=",
       "requires": {
         "@babel/core": "7.9.0",
         "@svgr/webpack": "4.3.3",
@@ -11186,7 +11139,7 @@
         "react-app-polyfill": "^1.0.6",
         "react-dev-utils": "^10.2.1",
         "resolve": "1.15.0",
-        "resolve-url-loader": "3.1.1",
+        "resolve-url-loader": "3.1.2",
         "sass-loader": "8.0.2",
         "semver": "6.3.0",
         "style-loader": "0.23.1",
@@ -11197,6 +11150,99 @@
         "webpack-dev-server": "3.11.0",
         "webpack-manifest-plugin": "2.2.0",
         "workbox-webpack-plugin": "4.3.1"
+      },
+      "dependencies": {
+        "adjust-sourcemap-loader": {
+          "version": "3.0.0",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/adjust-sourcemap-loader/-/adjust-sourcemap-loader-3.0.0.tgz",
+          "integrity": "sha1-WuEvtbexxYXoC7taY+wWOhpF5h4=",
+          "requires": {
+            "loader-utils": "^2.0.0",
+            "regex-parser": "^2.2.11"
+          },
+          "dependencies": {
+            "loader-utils": {
+              "version": "2.0.0",
+              "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/loader-utils/-/loader-utils-2.0.0.tgz",
+              "integrity": "sha1-5MrOW4FtQloWa18JfhDNErNgZLA=",
+              "requires": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+              }
+            }
+          }
+        },
+        "loader-utils": {
+          "version": "1.2.3",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/loader-utils/-/loader-utils-1.2.3.tgz",
+          "integrity": "sha1-H/XcaRHJ8KBiUxpMBLYJQGEIwsc=",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^2.0.0",
+            "json5": "^1.0.1"
+          },
+          "dependencies": {
+            "emojis-list": {
+              "version": "2.1.0",
+              "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/emojis-list/-/emojis-list-2.1.0.tgz",
+              "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+            },
+            "json5": {
+              "version": "1.0.1",
+              "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/json5/-/json5-1.0.1.tgz",
+              "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
+              "requires": {
+                "minimist": "^1.2.0"
+              }
+            }
+          }
+        },
+        "postcss": {
+          "version": "7.0.21",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/postcss/-/postcss-7.0.21.tgz",
+          "integrity": "sha1-BrsHgkwZwgIcXQVtWxDDW5iffhc=",
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "regex-parser": {
+          "version": "2.2.11",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/regex-parser/-/regex-parser-2.2.11.tgz",
+          "integrity": "sha1-OzfskEnhlHmAboeMq+fByoPM/lg="
+        },
+        "resolve-url-loader": {
+          "version": "3.1.2",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/resolve-url-loader/-/resolve-url-loader-3.1.2.tgz",
+          "integrity": "sha1-I14sKOIuPkMrp6XU4wXFmljt/Ag=",
+          "requires": {
+            "adjust-sourcemap-loader": "3.0.0",
+            "camelcase": "5.3.1",
+            "compose-function": "3.0.3",
+            "convert-source-map": "1.7.0",
+            "es6-iterator": "2.0.3",
+            "loader-utils": "1.2.3",
+            "postcss": "7.0.21",
+            "rework": "1.0.1",
+            "rework-visit": "1.0.0",
+            "source-map": "0.6.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "react-tap-event-plugin": {
@@ -11341,11 +11387,6 @@
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
       }
-    },
-    "regex-parser": {
-      "version": "2.2.10",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/regex-parser/-/regex-parser-2.2.10.tgz",
-      "integrity": "sha1-nmao9z2JoQdhbmOznU3t3+6RKzc="
     },
     "regexp.prototype.flags": {
       "version": "1.3.0",
@@ -11551,71 +11592,6 @@
       "version": "0.2.1",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-    },
-    "resolve-url-loader": {
-      "version": "3.1.1",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/resolve-url-loader/-/resolve-url-loader-3.1.1.tgz",
-      "integrity": "sha1-KJMYlfoeq5vgZH07KVjBAK48C/A=",
-      "requires": {
-        "adjust-sourcemap-loader": "2.0.0",
-        "camelcase": "5.3.1",
-        "compose-function": "3.0.3",
-        "convert-source-map": "1.7.0",
-        "es6-iterator": "2.0.3",
-        "loader-utils": "1.2.3",
-        "postcss": "7.0.21",
-        "rework": "1.0.1",
-        "rework-visit": "1.0.0",
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "emojis-list": {
-          "version": "2.1.0",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/emojis-list/-/emojis-list-2.1.0.tgz",
-          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
-        },
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "loader-utils": {
-          "version": "1.2.3",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/loader-utils/-/loader-utils-1.2.3.tgz",
-          "integrity": "sha1-H/XcaRHJ8KBiUxpMBLYJQGEIwsc=",
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^2.0.0",
-            "json5": "^1.0.1"
-          }
-        },
-        "postcss": {
-          "version": "7.0.21",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/postcss/-/postcss-7.0.21.tgz",
-          "integrity": "sha1-BrsHgkwZwgIcXQVtWxDDW5iffhc=",
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
     },
     "restore-cursor": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-router": "^3.0.0",
     "react-router-redux": "^4.0.8",
     "react-rte": "^0.16.3",
-    "react-scripts": "^3.4.3",
+    "react-scripts": "^3.4.4",
     "react-tap-event-plugin": "^2.0.1",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",


### PR DESCRIPTION
@QilongTang I added the .npmrc when I thought this repo was internal, thought it was just missed since the links in package-lock.json are to art-bobcat.  I'm not sure it makes sense to have it when it's external, as it would cause problems for users, but the existing package-lock.json would cause problems too.  Is it intentional that there is no .npmrc?