### PR TITLE
lodash vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2265,11 +2265,18 @@
       "integrity": "sha1-4eguTz6Zniz9YbFhKA0WoRH4ZCg="
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha1-PqNsXYgY0NX4qKl6bTa4bNwAyyc=",
+      "version": "0.21.1",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha1-IlY0gZYvTWvemnbVFu8OXTwJsrg=",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.10.0"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.14.0",
+          "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/follow-redirects/-/follow-redirects-1.14.0.tgz",
+          "integrity": "sha1-9dJg+VxfjBBYlEkf7uXciZO0Av4="
+        }
       }
     },
     "axobject-query": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13137,11 +13137,6 @@
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
       "integrity": "sha1-hTz5zpP2QvZxdCc8w0Vlrm8wh3c="
     },
-    "underscore": {
-      "version": "1.10.2",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha1-c9aqNmjzGI5K2w8ZQ70Sz9fvqq8="
-    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8196,9 +8196,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI="
+      "version": "4.17.21",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
     },
     "lodash-es": {
       "version": "4.17.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13133,9 +13133,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "ua-parser-js": {
-      "version": "0.7.21",
-      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha1-hTz5zpP2QvZxdCc8w0Vlrm8wh3c="
+      "version": "0.7.23",
+      "resolved": "https://art-bobcat.autodesk.com:443/artifactory/api/npm/autodesk-npm-virtual/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+      "integrity": "sha1-cE1n+VHhMZX7zT14gYV39bwdVHs="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "eslint-config-react-app": "^5.2.1",
     "jquery": "^3.1.1",
     "js-search": "^1.4.2",
+    "lodash": "^4.17.21",
     "material-ui": "^0.20.0",
     "octokit": "^0.10.4",
     "path": "^0.12.7",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react-tap-event-plugin": "^2.0.1",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",
-    "redux-thunk": "^2.2.0"
+    "redux-thunk": "^2.2.0",
+    "ua-parser-js": "^0.7.23"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {},
   "dependencies": {
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "classnames": "^2.2.5",
     "d3": "^4.4.2",
     "eslint-config-react-app": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "react-tap-event-plugin": "^2.0.1",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",
-    "redux-thunk": "^2.2.0",
-    "underscore": "^1.8.3"
+    "redux-thunk": "^2.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "react-tap-event-plugin": "^2.0.1",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",
-    "redux-thunk": "^2.2.0",
-    "ua-parser-js": "^0.7.23"
+    "redux-thunk": "^2.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/util/resort.js
+++ b/src/util/resort.js
@@ -1,4 +1,4 @@
-import _ from 'underscore';
+import _ from 'lodash';
 let resort = {};
 
 resort.removeDuplicates = function (data) {


### PR DESCRIPTION
add dep on new lodash to force `react-scripts` and `redux` to use that.

TODO:

- [x] replace underscore use with lodash
- [x] update `ua-parser-js` by updating package-lock.json
- [x] update `axios`.

dev server and static server seem to display a working dictionary, though I have not banged on it too much.