### PR TITLE
build only prod

### DIFF
--- a/scripts/Build.ps1
+++ b/scripts/Build.ps1
@@ -17,7 +17,7 @@ try
 
    Set-Location $WorkspacePath
 
-   npm install
+   npm ci --production
 
    if($LASTEXITCODE -ne 0)
    {


### PR DESCRIPTION
Build only for production seeing that we do not have any tests yet
When we will add tests ...we will need to have a separate prod + dev for testing and only prod for deployment and scanning